### PR TITLE
Add dbt staging models for Nordea transactions

### DIFF
--- a/dbt_project/models/staging/sources.yml
+++ b/dbt_project/models/staging/sources.yml
@@ -1,0 +1,34 @@
+version: 2
+
+sources:
+  - name: raw
+    description: Raw data loaded by Python scripts
+    schema: main
+    tables:
+      - name: raw_nordea_transactions
+        description: Raw Nordea bank transactions loaded from CSV exports
+        columns:
+          - name: transaction_hash
+            description: MD5 hash for deduplication (primary key)
+          - name: posting_date
+            description: Transaction posting date (NULL for pending)
+          - name: amount
+            description: Transaction amount in DKK (negative for debits)
+          - name: sender
+            description: Sender account number
+          - name: recipient
+            description: Recipient account number
+          - name: name
+            description: Transaction counterparty name
+          - name: description
+            description: Transaction description/merchant
+          - name: balance
+            description: Account balance after transaction
+          - name: currency
+            description: Currency code (DKK)
+          - name: reconciled
+            description: Reconciliation status
+          - name: source_file
+            description: Source CSV filename
+          - name: loaded_at
+            description: Timestamp when record was loaded

--- a/dbt_project/models/staging/stg_nordea_transactions.sql
+++ b/dbt_project/models/staging/stg_nordea_transactions.sql
@@ -1,0 +1,39 @@
+with source as (
+    select * from {{ source('raw', 'raw_nordea_transactions') }}
+),
+
+staged as (
+    select
+        -- Primary key
+        transaction_hash,
+
+        -- Date fields
+        posting_date,
+
+        -- Financial fields
+        amount,
+        balance,
+        currency,
+
+        -- Transaction parties
+        sender as sender_account,
+        recipient as recipient_account,
+        name as counterparty_name,
+        description as transaction_description,
+
+        -- Status
+        reconciled as is_reconciled,
+
+        -- Derived fields
+        case when amount < 0 then 'debit' else 'credit' end as transaction_type,
+        abs(amount) as absolute_amount,
+
+        -- Metadata
+        source_file,
+        loaded_at
+
+    from source
+    where posting_date is not null  -- Exclude pending transactions
+)
+
+select * from staged

--- a/dbt_project/models/staging/stg_nordea_transactions.yml
+++ b/dbt_project/models/staging/stg_nordea_transactions.yml
@@ -1,0 +1,50 @@
+version: 2
+
+models:
+  - name: stg_nordea_transactions
+    description: Staged Nordea bank transactions with cleaned column names and derived fields
+    columns:
+      - name: transaction_hash
+        description: Unique transaction identifier (MD5 hash)
+        tests:
+          - unique
+          - not_null
+      - name: posting_date
+        description: Transaction posting date
+        tests:
+          - not_null
+      - name: amount
+        description: Transaction amount (negative for debits, positive for credits)
+        tests:
+          - not_null
+      - name: balance
+        description: Account balance after transaction
+      - name: currency
+        description: Transaction currency
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['DKK']
+      - name: sender_account
+        description: Sender account number (populated for outgoing transfers)
+      - name: recipient_account
+        description: Recipient account number (populated for incoming transfers)
+      - name: counterparty_name
+        description: Name of the transaction counterparty
+      - name: transaction_description
+        description: Transaction description or merchant name
+      - name: is_reconciled
+        description: Whether transaction has been reconciled
+      - name: transaction_type
+        description: Derived transaction type (debit or credit)
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['debit', 'credit']
+      - name: absolute_amount
+        description: Absolute value of the transaction amount
+      - name: source_file
+        description: Original CSV source file
+      - name: loaded_at
+        description: Timestamp when the record was loaded into staging


### PR DESCRIPTION
## Summary
- Create `sources.yml` defining `raw_nordea_transactions` as a dbt source
- Create `stg_nordea_transactions` staging model with renamed columns and derived fields (`transaction_type`, `absolute_amount`)
- Add schema tests: unique/not_null on `transaction_hash`, not_null on required fields, accepted_values validation
- Add dbt documentation for all columns

Closes #2

## Test plan
- [x] `dbt run --select stg_nordea_transactions` - PASS
- [x] `dbt test --select stg_nordea_transactions` - 7 tests PASS
- [x] `dbt docs generate` - Complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)