### PR TITLE
Add fact table (fct_transactions)

### DIFF
--- a/dbt_project/models/marts/fct_transactions.sql
+++ b/dbt_project/models/marts/fct_transactions.sql
@@ -1,0 +1,39 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+with transactions as (
+    select * from {{ ref('stg_nordea_transactions') }}
+),
+
+final as (
+    select
+        -- Keys
+        transaction_hash as transaction_key,
+        posting_date as date_key,
+        coalesce(sender_account, recipient_account) as account_key,
+
+        -- Measures
+        amount,
+        absolute_amount,
+        balance,
+
+        -- Attributes
+        transaction_type,
+        counterparty_name,
+        transaction_description,
+        currency,
+
+        -- Future: category_key (will be populated by categorization system)
+        null::varchar as category_key,
+
+        -- Metadata
+        source_file,
+        loaded_at
+
+    from transactions
+)
+
+select * from final

--- a/dbt_project/models/marts/schema.yml
+++ b/dbt_project/models/marts/schema.yml
@@ -60,3 +60,54 @@ models:
         description: Default currency for the account
       - name: account_type
         description: Type of account (Checking, Savings, etc.)
+
+  - name: fct_transactions
+    description: Fact table containing all bank transactions
+    columns:
+      - name: transaction_key
+        description: Primary key (transaction hash)
+        tests:
+          - unique
+          - not_null
+      - name: date_key
+        description: Foreign key to dim_date
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_date')
+                field: date_key
+      - name: account_key
+        description: Foreign key to dim_account
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_account')
+                field: account_key
+      - name: amount
+        description: Transaction amount (negative for debits, positive for credits)
+        tests:
+          - not_null
+      - name: absolute_amount
+        description: Absolute value of transaction amount
+      - name: balance
+        description: Account balance after transaction
+      - name: transaction_type
+        description: Type of transaction (debit or credit)
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['debit', 'credit']
+      - name: counterparty_name
+        description: Name of the transaction counterparty
+      - name: transaction_description
+        description: Transaction description or merchant name
+      - name: currency
+        description: Transaction currency
+      - name: category_key
+        description: Foreign key to dim_category (future use)
+      - name: source_file
+        description: Original CSV source file
+      - name: loaded_at
+        description: Timestamp when the record was loaded


### PR DESCRIPTION
## Summary
- Create `fct_transactions` fact table with:
  - `transaction_key` (primary key from hash)
  - `date_key` (FK to dim_date)
  - `account_key` (FK to dim_account, using coalesce of sender/recipient)
  - Amount, balance, transaction type, counterparty, description
  - Placeholder `category_key` for future categorization
- Add relationship tests to verify FK integrity
- Add schema documentation

Closes #4

## Test plan
- [x] `dbt run --select fct_transactions` - PASS
- [x] `dbt test --select fct_transactions` - 8 tests PASS (unique, not_null, relationships, accepted_values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)